### PR TITLE
Fix payload_param setting

### DIFF
--- a/telemetry/gparser/parser.py
+++ b/telemetry/gparser/parser.py
@@ -104,9 +104,13 @@ class Parser:
         self.artifact_info_type=file_info[3]
         self.payload_raw=self.get_payload_raw()
         payload_parsed=self.get_payload_parsed()
-        self.payload=payload_parsed[0]
         if len(payload_parsed) == 2:
+            self.payload=payload_parsed[0]
             self.payload_param=payload_parsed[1]
+        else:
+            self.payload=payload_parsed
+            for k in range(len(payload_parsed)):
+                self.payload_param.append("NA") 
 
     def show_info(self):
         return self.__dict__


### PR DESCRIPTION
payload_param is not set for non Pytest artifacts. I added a conditional to set default value to a list of "NA".

I also cleaned up the profile param for profile write tests to exclude the full path which varies across Jenkins projects.