### PR TITLE
production_testing: change synchrona log function to standard

### DIFF
--- a/telemetry/cli.py
+++ b/telemetry/cli.py
@@ -21,9 +21,10 @@ def cli():
 @click.option("--username", default=None, help="Username for mongo server")
 @click.option("--password", default=None, help="Password for mongo server")
 @click.option("--dbname", default=None, help="Target collection for mongo server")
-def prod_synchrona_upload(tdir, server, username, password, dbname):
+@click.option("--board", default=None, help="Name of target board")
+def prod_logs_upload(tdir, server, username, password, dbname, board):
     """Upload unprocessed test logs to mongo for synchrona."""
-    sync = telemetry.prod.SynchronaLog(server, username, password, dbname)
+    sync = telemetry.prod.BoardLog(server, username, password, dbname, board)
     sync.default_unprocessed_log_dir = tdir
     sync.default_processed_log_dir = os.path.join(tdir, "processed")
     if not os.path.isdir(sync.default_processed_log_dir):
@@ -171,7 +172,7 @@ def main(args=None):
     return 0
 
 
-cli.add_command(prod_synchrona_upload)
+cli.add_command(prod_logs_upload)
 cli.add_command(log_boot_logs)
 cli.add_command(log_hdl_resources_from_csv)
 cli.add_command(log_artifacts)

--- a/telemetry/prod/__init__.py
+++ b/telemetry/prod/__init__.py
@@ -1,5 +1,5 @@
 """Production Public Class Interfaces"""
-from .synchrona import SynchronaLog as __sl
+from .board_log import BoardLog as __sl
 
-class SynchronaLog(__sl):
+class BoardLog(__sl):
     pass

--- a/telemetry/prod/board_log.py
+++ b/telemetry/prod/board_log.py
@@ -6,9 +6,8 @@ from .common import ProductionLog
 import pymongo
 
 
-class SynchronaLog(ProductionLog):
+class BoardLog(ProductionLog):
 
-    board_name = "AD-SYNCHRONA14-EBZ"
     skip_insert = True
     default_unprocessed_log_dir = "/test/logs/unprocessed"
     default_processed_log_dir = "/test/logs/processed"

--- a/telemetry/prod/common.py
+++ b/telemetry/prod/common.py
@@ -14,8 +14,9 @@ class ProductionLog(metaclass=ABCMeta):
     }
 
     skip_insert = False
+    board_name = ""
 
-    def __init__(self, server=None, username=None, password=None, dbname=None) -> None:
+    def __init__(self, server=None, username=None, password=None, dbname=None, boardname=None) -> None:
 
         if not server:
             server = os.getenv("DBSERVER")
@@ -25,7 +26,10 @@ class ProductionLog(metaclass=ABCMeta):
             password = os.getenv("DBPASSWORD")
         if not dbname:
             dbname = os.getenv("DBNAME")
-
+        if not boardname:
+            self.board_name = os.getenv("BOARD_NAME")
+        else:
+            self.board_name = boardname
         cmd = f"mongodb+srv://{username}:{password}@{server}/"
 
         try:
@@ -49,14 +53,6 @@ class ProductionLog(metaclass=ABCMeta):
 
     @abstractmethod
     def process_logs(self) -> None:
-        """Name of driver used for transmitting data.
-        This is the IIO device used collect data from.
-        """
-        raise NotImplementedError  # pragma: no cover
-
-    @property
-    @abstractmethod
-    def board_name(self) -> None:
         """Name of driver used for transmitting data.
         This is the IIO device used collect data from.
         """

--- a/tests/test_prod.py
+++ b/tests/test_prod.py
@@ -8,19 +8,19 @@ import datetime
 @pytest.fixture(autouse=True)
 def run_around_tests():
     # Before test
-    sync = telemetry.prod.SynchronaLog()
+    sync = telemetry.prod.BoardLog()
     result = sync.collection.delete_many({})
     yield
     # After test
-    sync = telemetry.prod.SynchronaLog()
+    sync = telemetry.prod.BoardLog()
     result = sync.collection.delete_many({})
 
 
 def test_prod_synchrona_example_import():
-    sync = telemetry.prod.SynchronaLog()
+    sync = telemetry.prod.BoardLog()
     pwd = os.path.dirname(os.path.abspath(__file__))
     artifact_dir = os.path.join(pwd, "prod_example_artifacts")
-    sync = telemetry.prod.SynchronaLog()
+    sync = telemetry.prod.BoardLog()
     sync.default_unprocessed_log_dir = artifact_dir
     sync.default_processed_log_dir = os.path.join(artifact_dir, "processed")
     if not os.path.isdir(sync.default_processed_log_dir):


### PR DESCRIPTION
Use the same function for logging several boards,
and add --board parameter to specify board name.

Signed-off-by: Ramona Alexandra Nechita <ramona.nechita@analog.com>