### PR TITLE
Send production logs to different database instead of sdg

### DIFF
--- a/telemetry/prod/common.py
+++ b/telemetry/prod/common.py
@@ -42,7 +42,7 @@ class ProductionLog(metaclass=ABCMeta):
                 print(e1, e2)
                 raise Exception("Unable to connect to MongoDB")
 
-        db = self.client["sdg"]
+        db = self.client["production_test1"]
         self.collection = db[dbname]
 
     def _ref_scheme(self):


### PR DESCRIPTION
A new database was added for the production testing logs, called "production_test1". The log upload command was updated to push data there.